### PR TITLE
Start a scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Smoke Tests, tests to verify if the happy path is functioning [14](https://github.com/greenbone/eulabeia/pull/14)
 - Unittests for openvas module [24](https://github.com/greenbone/eulabeia/pull/24)
 - Adapt target credentials to allow different types [27](https://github.com/greenbone/eulabeia/pull/27)
+- Adapt sensor so it is able to start a scan now [30](https://github.com/greenbone/eulabeia/pull/30)
 ### Changed
 - Split cmds and info messages into own module [8](https://github.com/greenbone/eulabeia/pull/8)
 - Normalized topic structure to `group/aggregate/event/destination`; setting topic based on return message rather than configuration [8](https://github.com/greenbone/eulabeia/pull/8)

--- a/cmd/eulabeia-sensor/main.go
+++ b/cmd/eulabeia-sensor/main.go
@@ -70,6 +70,8 @@ func main() {
 	log.Printf("Starting Scheduler")
 	sens.Start()
 	process.Block(client)
+	log.Printf("Stopping Scheduler")
 	term := sens.Stop()
+	log.Printf("Wait for all OpenVAS processes to end.")
 	<-term
 }

--- a/cmd/eulabeia-sensor/main.go
+++ b/cmd/eulabeia-sensor/main.go
@@ -69,9 +69,5 @@ func main() {
 	sens := sensor.NewScheduler(client, configuration.Sensor.Id, configuration.ScannerPreferences)
 	log.Printf("Starting Scheduler")
 	sens.Start()
-	process.Block(client)
-	log.Printf("Stopping Scheduler")
-	term := sens.Stop()
-	log.Printf("Wait for all OpenVAS processes to end.")
-	<-term
+	process.Block(client, sens)
 }

--- a/cmd/eulabeia-sensor/main.go
+++ b/cmd/eulabeia-sensor/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/greenbone/eulabeia/messages"
 	"github.com/greenbone/eulabeia/messages/cmds"
 	"github.com/greenbone/eulabeia/process"
+	"github.com/greenbone/eulabeia/sensor"
 )
 
 func main() {
@@ -65,17 +66,10 @@ func main() {
 	if err != nil {
 		log.Panicf("Failed to connect: %s", err)
 	}
-	client.Publish("eulabeia/sensor/cmd/director", cmds.Modify{
-		Identifier: messages.Identifier{
-			Message: messages.NewMessage("modify.sensor", "", ""),
-			ID:      configuration.Sensor.Id,
-		},
-		Values: map[string]interface{}{
-			"type": "undefined",
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
+	sens := sensor.NewScheduler(client, configuration.Sensor.Id, configuration.ScannerPreferences)
+	log.Printf("Starting Scheduler")
+	sens.Start()
 	process.Block(client)
+	term := sens.Stop()
+	<-term
 }

--- a/director/sensor/sensor.go
+++ b/director/sensor/sensor.go
@@ -55,7 +55,7 @@ func (t sensorAggregate) Modify(m cmds.Modify) (*info.Modified, *info.Failure, e
 	if err != nil {
 		return nil, nil, err
 	} else if sensor == nil {
-		log.Printf("Scan %s not found, creating a new one.\n", m.ID)
+		log.Printf("Sensor %s not found, creating a new one.\n", m.ID)
 		sensor = &models.Sensor{
 			ID: m.ID,
 		}

--- a/process/block.go
+++ b/process/block.go
@@ -26,15 +26,18 @@ import (
 	"log"
 )
 
-func Block(c io.Closer) {
+func Block(c ...io.Closer) {
 	BlockUntil(func() {
 		log.Println("Exiting")
-		if c != nil {
-			err := c.Close()
-			if err != nil {
-				log.Fatalf("failed to send Disconnect: %s", err)
+		for _, cl := range c {
+			if cl != nil {
+				err := cl.Close()
+				if err != nil {
+					log.Fatalf("failed to send Disconnect: %s", err)
+				}
 			}
 		}
+
 	}, os.Interrupt, syscall.SIGTERM)
 }
 

--- a/sensor/handler/handler.go
+++ b/sensor/handler/handler.go
@@ -48,10 +48,18 @@ func (handler StartStop) On(topic string, message []byte) (*connection.SendRespo
 
 type Registered struct {
 	RegChan chan struct{}
+	ID      string
 }
 
 func (handler Registered) On(topic string, message []byte) (*connection.SendResponse, error) {
-	handler.RegChan <- struct{}{}
+	var msg info.Created
+	err := json.Unmarshal(message, &msg)
+	if err != nil {
+		return nil, err
+	}
+	if msg.ID == handler.ID {
+		handler.RegChan <- struct{}{}
+	}
 	return nil, nil
 }
 

--- a/sensor/scanner/openvas/openvas.go
+++ b/sensor/scanner/openvas/openvas.go
@@ -28,10 +28,23 @@ import (
 	"sync"
 )
 
+// OpenVASScanner is the eulabeia scanner implementation of openvas. It is
+// responsible for handling processes of openvas. It also is able to start and
+// stop scans via openvas.
+type OpenVASScanner struct {
+	procs map[string]*os.Process // Process List for running scans
+	mutex *sync.Mutex            // For thread save management of processes
+	exe   Commander              // Commander to use to run commands
+	sudo  bool                   // Decides if scans should be run as sudo
+}
+
+// Commander is an inferace to manage different ways to handle calls to openvas.
+// It is mostly used for testing purposes.
 type Commander interface {
 	Command(name string, arg ...string) *exec.Cmd
 }
 
+// stdCommander is the standard commander.
 type StdCommander struct {
 }
 
@@ -39,50 +52,48 @@ func (exe StdCommander) Command(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
 }
 
-// ProcessList represents a list of processes. It is used to manage processes
-// within different go routines.
-type ProcessList struct {
-	procs map[string]*os.Process
-	mutex *sync.Mutex
-}
+// CreateNewOpenVASScanner creates a new instance of an OpenVASScanner with the
+// specified settings.
+func CreateNewOpenVASScanner(cmd Commander, sudo bool) *OpenVASScanner {
 
-func CreateEmptyProcessList() ProcessList {
-	return ProcessList{
+	return &OpenVASScanner{
 		procs: make(map[string]*os.Process),
 		mutex: &sync.Mutex{},
+		exe:   cmd,
+		sudo:  sudo,
 	}
 }
 
 // addProcess adds a Process to the Process list
-func (pl ProcessList) addProcess(scan string, p *os.Process) error {
-	pl.mutex.Lock()
-	defer pl.mutex.Unlock()
-	if _, ok := pl.procs[scan]; ok {
+func (ovas OpenVASScanner) addProcess(scan string, p *os.Process) error {
+	ovas.mutex.Lock()
+	defer ovas.mutex.Unlock()
+	if _, ok := ovas.procs[scan]; ok {
 		return errors.New("process already exist")
 	}
-	pl.procs[scan] = p
+	ovas.procs[scan] = p
 	return nil
 }
 
 // removeProcess removes a Process from the Process list
-func (pl ProcessList) removeProcess(scan string) error {
-	pl.mutex.Lock()
-	defer pl.mutex.Unlock()
-	if _, ok := pl.procs[scan]; !ok {
+func (ovas OpenVASScanner) removeProcess(scan string) error {
+	ovas.mutex.Lock()
+	defer ovas.mutex.Unlock()
+	if _, ok := ovas.procs[scan]; !ok {
 		return errors.New("process does not exist")
 	}
-	delete(pl.procs, scan)
+	delete(ovas.procs, scan)
 	return nil
 }
 
 // StartScan starts scan with given scan-ID and process priority (-20 to 19,
 // lower is more prioritized)
-func StartScan(scan string, niceness int, sudo bool, exe Commander, procList ProcessList) error {
+func (ovas OpenVASScanner) StartScan(scan string, niceness int) error {
 	cmdString := make([]string, 0)
 
 	cmdString = append(cmdString, "nice", "-n", fmt.Sprintf("%v", niceness))
 
-	if sudo {
+	if ovas.sudo {
 		cmdString = append(cmdString, "sudo", "-n")
 	}
 
@@ -91,27 +102,27 @@ func StartScan(scan string, niceness int, sudo bool, exe Commander, procList Pro
 	head := cmdString[0]
 	args := cmdString[1:]
 
-	cmd := exe.Command(head, args...)
+	cmd := ovas.exe.Command(head, args...)
 
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("unable to start openvas process: %s", err)
 	}
-	procList.addProcess(scan, cmd.Process)
-	go waitForProcessToEnd(cmd.Process, scan, procList)
+	ovas.addProcess(scan, cmd.Process)
+	go ovas.waitForProcessToEnd(cmd.Process, scan)
 	return nil
 }
 
 // StopScan stops a scan with given scan-ID
-func StopScan(scan string, sudo bool, exe Commander, procList ProcessList) error {
-	err := procList.removeProcess(scan)
+func (ovas OpenVASScanner) StopScan(scan string) error {
+	err := ovas.removeProcess(scan)
 	if err != nil {
 		return err
 	}
 
 	cmdString := make([]string, 0)
 
-	if sudo {
+	if ovas.sudo {
 		cmdString = append(cmdString, "sudo", "-n")
 	}
 
@@ -120,7 +131,7 @@ func StopScan(scan string, sudo bool, exe Commander, procList ProcessList) error
 	head := cmdString[0]
 	args := cmdString[1:]
 
-	cmd := exe.Command(head, args...)
+	cmd := ovas.exe.Command(head, args...)
 
 	err = cmd.Run()
 	if err != nil {
@@ -131,13 +142,13 @@ func StopScan(scan string, sudo bool, exe Commander, procList ProcessList) error
 }
 
 // ScanFinished must be called when a Openvas Process succesfully finished
-func ScanFinished(scan string, procList ProcessList) error {
-	return procList.removeProcess(scan)
+func (ovas OpenVASScanner) ScanFinished(scan string) error {
+	return ovas.removeProcess(scan)
 }
 
 // GetVersion returns the Version of OpenVAS
-func GetVersion(exe Commander) (string, error) {
-	out, err := exe.Command("openvas", "-V").CombinedOutput()
+func (ovas OpenVASScanner) GetVersion() (string, error) {
+	out, err := ovas.exe.Command("openvas", "-V").CombinedOutput()
 	if err != nil {
 		return "", err
 	}
@@ -146,8 +157,8 @@ func GetVersion(exe Commander) (string, error) {
 }
 
 // GetSettings returns the Settings of OpenVAS as a map
-func GetSettings(exe Commander) (map[string]string, error) {
-	out, err := exe.Command("openvas", "-s").CombinedOutput()
+func (ovas OpenVASScanner) GetSettings() (map[string]string, error) {
+	out, err := ovas.exe.Command("openvas", "-s").CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
@@ -164,8 +175,8 @@ func GetSettings(exe Commander) (map[string]string, error) {
 }
 
 // LoadVTsIntoRedis starts openvas which then loads new VTs into Redis
-func LoadVTsIntoRedis(exe Commander) error {
-	return exe.Command("openvas", "--update-vt-info").Run()
+func (ovas OpenVASScanner) LoadVTsIntoRedis() error {
+	return ovas.exe.Command("openvas", "--update-vt-info").Run()
 }
 
 // IsSudo checks for sudo permissions
@@ -177,13 +188,13 @@ func IsSudo(exe Commander) bool {
 
 // waitForProcessToEnd gets Called as go-routine after OpenVAS Scan Process was
 // started
-func waitForProcessToEnd(p *os.Process, scan string, procList ProcessList) {
+func (ovas OpenVASScanner) waitForProcessToEnd(p *os.Process, scan string) {
 	p.Wait()
-	err := procList.removeProcess(scan)
+	err := ovas.removeProcess(scan)
 	if err == nil {
-		log.Printf("%s: Scan process got unexpectedly stopped or killed.\n", scan)
+		log.Printf("%s: Scan process with PID %d got unexpectedly stopped or killed.\n", scan, p.Pid)
 		// TODO: Interrupt scan
 		return
 	}
-	log.Printf("%s: Scan process with PID %v terminated correctly.\n", scan, p.Pid)
+	log.Printf("%s: Scan process with PID %d terminated correctly.\n", scan, p.Pid)
 }

--- a/sensor/scanner/openvas/openvas_test.go
+++ b/sensor/scanner/openvas/openvas_test.go
@@ -39,7 +39,7 @@ type helperLongCommander struct {
 }
 
 func (exe helperLongCommander) Command(name string, arg ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestCommandEndless", "--", name}
+	cs := []string{"-test.run=TestCommandLong", "--", name}
 	cs = append(cs, arg...)
 	cmd := exec.Command(os.Args[0], cs...)
 	cmd.Env = []string{"GO_TEST_PROCESS=1"}
@@ -48,13 +48,11 @@ func (exe helperLongCommander) Command(name string, arg ...string) *exec.Cmd {
 
 // TestCommandEndless is not a real test. It is only used as a helper process to
 // simulate long running programm such as a scan in openvas
-func TestCommandEndless(t *testing.T) {
+func TestCommandLong(t *testing.T) {
 	if os.Getenv("GO_TEST_PROCESS") != "1" {
 		return
 	}
-	for {
-		time.Sleep(time.Second)
-	}
+	time.Sleep(time.Second)
 }
 
 // helperFailCommander creates a Command to execute a programm with a exit code 1

--- a/sensor/scanner/openvas/openvas_test.go
+++ b/sensor/scanner/openvas/openvas_test.go
@@ -127,15 +127,16 @@ func TestCommandSettings(t *testing.T) {
 // TestStartStopScanSudo tests the procedure of creating an openvas process and stopping it with sudo privileges
 func TestStartStopScanSudo(t *testing.T) {
 	// OpenVASScanner instance
-	ovas := CreateNewOpenVASScanner(helperLongCommander{}, IsSudo(helperShortCommander{}))
+	ovas := NewOpenVASScanner()
+	sudo := IsSudo(helperShortCommander{})
 
 	// Test for sudo rights
-	if !ovas.sudo {
-		t.Fatalf("Error: Sudo is %t, but should be %t", ovas.sudo, true)
+	if !sudo {
+		t.Fatalf("Error: Sudo is %t, but should be %t", sudo, true)
 	}
 
 	// Start scan
-	if err := ovas.StartScan("foo", 10); err != nil {
+	if err := ovas.StartScan("foo", 10, sudo, helperLongCommander{}); err != nil {
 		t.Fatalf("Error: Cannot run StartScan: %s", err)
 	}
 
@@ -145,7 +146,7 @@ func TestStartStopScanSudo(t *testing.T) {
 	}
 
 	// Stop Scan
-	if err := ovas.StopScan("foo"); err != nil {
+	if err := ovas.StopScan("foo", sudo, helperShortCommander{}); err != nil {
 		t.Fatalf("Error: Unable to stop process: %s", err)
 	}
 
@@ -158,15 +159,16 @@ func TestStartStopScanSudo(t *testing.T) {
 // TestNonSudoStopScanFail tests if it fails to stop a scan when there is no scan to stop
 func TestNonSudoStopScanFail(t *testing.T) {
 	// OpenVASScanner instance
-	ovas := CreateNewOpenVASScanner(helperShortCommander{}, IsSudo(helperFailCommander{}))
+	ovas := NewOpenVASScanner()
+	sudo := IsSudo(helperFailCommander{})
 
 	// Test if sudo is unavailable
-	if ovas.sudo {
-		t.Fatalf("Error: Sudo is %t, but should be %t", ovas.sudo, false)
+	if sudo {
+		t.Fatalf("Error: Sudo is %t, but should be %t", sudo, false)
 	}
 
 	// Stop Scan should fail because ther is no process
-	if err := ovas.StopScan("foo"); err == nil {
+	if err := ovas.StopScan("foo", sudo, helperShortCommander{}); err == nil {
 		t.Fatalf("Error: Should be unable to successfully stop scan")
 	}
 }
@@ -174,7 +176,7 @@ func TestNonSudoStopScanFail(t *testing.T) {
 // TestScanFinishedSuccess tests if it can mark a scan as finished
 func TestScanFinishedSuccess(t *testing.T) {
 	// OpenVASScanner instance
-	ovas := CreateNewOpenVASScanner(nil, false)
+	ovas := NewOpenVASScanner()
 
 	ovas.addProcess("foo", nil)
 
@@ -186,7 +188,7 @@ func TestScanFinishedSuccess(t *testing.T) {
 // TestScanFinishedFail tests if marking a scan as finished fails if there is no scan to finish
 func TestScanFinishedFail(t *testing.T) {
 	// OpenVASScanner instance
-	ovas := CreateNewOpenVASScanner(nil, false)
+	ovas := NewOpenVASScanner()
 
 	if err := ovas.ScanFinished("foo"); err == nil {
 		t.Fatalf("Error: ScanFinished should return an error")
@@ -196,9 +198,9 @@ func TestScanFinishedFail(t *testing.T) {
 // TestGetVersion tests if the information getting from the openvas version is extracted correctly
 func TestGetVersion(t *testing.T) {
 	// OpenVASScanner instance
-	ovas := CreateNewOpenVASScanner(helperVersionCommander{}, false)
+	ovas := NewOpenVASScanner()
 
-	ver, err := ovas.GetVersion()
+	ver, err := ovas.GetVersion(helperVersionCommander{})
 	if err != nil {
 		t.Fatalf("Error: Unable to get Version")
 	}
@@ -210,9 +212,9 @@ func TestGetVersion(t *testing.T) {
 // TestGetSettings tests if the information getting from the openvas settings is extracted correctly
 func TestGetSettings(t *testing.T) {
 	// OpenVASScanner instance
-	ovas := CreateNewOpenVASScanner(helperSettingsCommander{}, false)
+	ovas := NewOpenVASScanner()
 
-	set, err := ovas.GetSettings()
+	set, err := ovas.GetSettings(helperSettingsCommander{})
 	fmt.Printf("%v\n", set)
 
 	if err != nil {

--- a/sensor/scanner/scanner.go
+++ b/sensor/scanner/scanner.go
@@ -1,5 +1,6 @@
 package scanner
 
+// Scanner interface defines which functionality a scanner must have
 type Scanner interface {
 	StartScan(scan string, niceness int) error
 	StopScan(scan string) error

--- a/sensor/scanner/scanner.go
+++ b/sensor/scanner/scanner.go
@@ -1,0 +1,9 @@
+package scanner
+
+type Scanner interface {
+	StartScan(scan string, niceness int) error
+	StopScan(scan string) error
+	ScanFinished(scan string) error
+	GetVersion() (string, error)
+	GetSettings() (map[string]string, error)
+}

--- a/sensor/sensor.go
+++ b/sensor/sensor.go
@@ -76,7 +76,9 @@ func (sensor Scheduler) schedule() {
 	go loadVTs(vtsLoadedChan, ovas)
 
 	for { // Infinite scheduler Loop
-		for vtsLoading || len(queue) == 0 { // Check for new stuff in Channels
+		first := true
+		for first || vtsLoading || len(queue) == 0 { // Check for new stuff in Channels
+			first = false
 			select {
 			case scan := <-sensor.startChan: // start scan
 				queue = append(queue, scan)
@@ -173,7 +175,7 @@ func (sensor Scheduler) schedule() {
 		}
 
 		// Check for free scanner slot
-		if len(init)+len(running) == int(sensor.conf.MaxScan) {
+		if sensor.conf.MaxScan > 0 && len(init)+len(running) == int(sensor.conf.MaxScan) {
 			log.Printf("Unable to start a scan from queue, Max number of scans reached.\n")
 			continue
 		}

--- a/sensor/sensor.go
+++ b/sensor/sensor.go
@@ -152,6 +152,7 @@ func (sensor Scheduler) schedule() {
 				vtsLoading = false
 
 			case <-sensor.termChan:
+				log.Print("Cleaning all OpenVAS Processes...\n")
 				// Stopping all init processes
 				for _, v := range init {
 					ovas.StopScan(v, sudo, openvas.StdCommander{})
@@ -230,9 +231,11 @@ func (sensor Scheduler) register() {
 	}
 }
 
-func (sensor Scheduler) Stop() chan struct{} {
+func (sensor Scheduler) Close() error {
+	log.Print("Stopping scheduler...\n")
 	sensor.termChan <- struct{}{}
-	return sensor.terminatedChan
+	<-sensor.terminatedChan
+	return nil
 }
 
 // Start initializes MQTT handling and starts the scheduler

--- a/sensor/sensor.go
+++ b/sensor/sensor.go
@@ -35,7 +35,7 @@ import (
 	"github.com/greenbone/eulabeia/util"
 )
 
-type Sensor struct {
+type Scheduler struct {
 	startChan      chan string   // Channel to insert scan into queue
 	stopChan       chan string   // Channel to delete scan from queue
 	runChan        chan string   // Channel to delete scan from init and insert it into running
@@ -63,7 +63,7 @@ func loadVTs(vtsLoadedChan chan struct{}, ovas *openvas.OpenVASScanner) {
 }
 
 // Checks for new instructions for the sensor and starts queued scans.
-func (sensor Sensor) schedule() {
+func (sensor Scheduler) schedule() {
 	queue := make([]string, 0)
 	init := make([]string, 0)
 	running := make([]string, 0)
@@ -209,7 +209,7 @@ func (sensor Sensor) schedule() {
 }
 
 // register loops until its ID is registrated
-func (sensor Sensor) register() {
+func (sensor Scheduler) register() {
 	for { // loop until sensor is registered
 		sensor.mqtt.Publish("eulabeia/sensor/cmd/director", cmds.Register{
 			Identifier: messages.Identifier{
@@ -226,13 +226,13 @@ func (sensor Sensor) register() {
 	}
 }
 
-func (sensor Sensor) Stop() chan struct{} {
+func (sensor Scheduler) Stop() chan struct{} {
 	sensor.termChan <- struct{}{}
 	return sensor.terminatedChan
 }
 
 // Start initializes MQTT handling and starts the scheduler
-func (sensor Sensor) Start() {
+func (sensor Scheduler) Start() {
 	// Subscribe on Topic to get confirmation about registration
 	sensor.mqtt.Subscribe(map[string]connection.OnMessage{
 		fmt.Sprintf("eulabeia/sensor/info/%s", sensor.id): handler.Registered{
@@ -271,8 +271,8 @@ func (sensor Sensor) Start() {
 	go sensor.schedule()
 }
 
-func NewScheduler(mqtt connection.PubSub, id string, conf config.ScannerPreferences) *Sensor {
-	return &Sensor{
+func NewScheduler(mqtt connection.PubSub, id string, conf config.ScannerPreferences) *Scheduler {
+	return &Scheduler{
 		startChan:      make(chan string),
 		stopChan:       make(chan string),
 		runChan:        make(chan string),

--- a/sensor/sensor.go
+++ b/sensor/sensor.go
@@ -72,8 +72,9 @@ func (sensor Scheduler) schedule() {
 	sudo := openvas.IsSudo(openvas.StdCommander{})
 
 	var vtsLoadedChan = make(chan struct{})
-	vtsLoading := true
-	go loadVTs(vtsLoadedChan, ovas)
+	// TODO: Adjust loading VTs as soon as they are available
+	vtsLoading := false
+	// go loadVTs(vtsLoadedChan, ovas)
 
 	for { // Infinite scheduler Loop
 		first := true


### PR DESCRIPTION
**What**:
The sensor now registers itself at the director. This is currently done by a modify as the director currently does not support the register message. From sensor perspective a scan can now be started. SC-325
I renamed the scheduler module to sensor as it is the main component running the scheduler. Also I refactored this module for cleaner code.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
PROGRESS!!!

<!-- Why are these changes necessary? -->

**How**:
First you have to start the MQTT Broker and adjust the Connection settings in the config.toml File to match the local Broker settings. For the StoragePath setting it is important, that the given Path does exist, it does not create it automatically. All other settings can stay the same. Start the director and the scanner (order does not matter). The scanner should register itself automatically at the director. After that the sensor calls openvas to load VTs into redis (this can be seen with e.g. htop, just filter `openvas`). Now a scan can be started with a MQTT message:
```json
{
  "message_type":"scan.start",
  "id":"foo"
}
```
I used MQTT Explorer to send this message. Now a new openvas process can be seen in the process list (htop).
Also openvas starts to log messages into its logfile.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] CHANGELOG.md entry
- [ ] Documentation
