### PR TITLE
Start sensor scan via example-client and director

### DIFF
--- a/cmd/eulabeia-sensor/main.go
+++ b/cmd/eulabeia-sensor/main.go
@@ -49,7 +49,7 @@ func main() {
 		configuration.Sensor.Id = sensor_id
 	}
 
-	log.Println("Starting sensor")
+	log.Printf("Starting sensor (%s)", configuration.Sensor.Id)
 	client, err := mqtt.New(server, configuration.Sensor.Id, "", "",
 		&mqtt.LastWillMessage{
 			Topic: "eulabeia/sensor/cmd/director",

--- a/cmd/example-client/main.go
+++ b/cmd/example-client/main.go
@@ -86,6 +86,9 @@ func (e *ExampleHandler) On(topic string, msg []byte) (*connection.SendResponse,
 	// We assume that if there is no response message that the test scenario is finished
 	if response == nil {
 		e.exit <- syscall.SIGCONT
+		// on response.Topic ignore SendResponse
+	} else if response.Topic == "" {
+		return nil, nil
 	}
 	return response, nil
 }
@@ -119,11 +122,11 @@ func MegaScan(msg info.IDInfo) *connection.SendResponse {
 			ID: MEGA_ID,
 			Target: models.Target{
 				ID:       MEGA_ID,
-				Hosts:    []string{"hosts1"},
-				Ports:    []string{"ports1"},
-				Plugins:  []string{"plugins1"},
+				Hosts:    []string{"localhost"},
+				Ports:    []string{"80"},
+				Plugins:  []string{"1.3.6.1.4.1.25623.1.0.90022"},
 				Exclude:  []string{"exclude1"},
-				Sensor:   "sensor",
+				Sensor:   "localhorst",
 				Alive:    true,
 				Parallel: true,
 				Credentials: map[string]map[string]string{
@@ -136,6 +139,14 @@ func MegaScan(msg info.IDInfo) *connection.SendResponse {
 		},
 	}
 	return messages.EventToResponse(context, mega)
+}
+
+func VerifyForScanStatus(i info.IDInfo) *connection.SendResponse {
+	if i.Type == "scan.status" {
+		return nil
+	} else {
+		return &connection.SendResponse{}
+	}
 }
 
 func Done(_ info.IDInfo) *connection.SendResponse {
@@ -191,7 +202,7 @@ func main() {
 			CREATED_TARGET:  ModifyTarget,
 			MODIFIED_TARGET: CreateScan,
 			MODIFIED_SCAN:   MegaScan,
-			MEGA_ID:         Done,
+			MEGA_ID:         VerifyForScanStatus,
 		},
 		exit: ic,
 	}

--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,9 @@ minFreeMemScanQueue = 0  # 0 = disabled
 maxQueuedScans = 0  # 0 = disabled
 niceness = 10
 
+[Sensor]
+Id = "localhorst"
+
 [Director]
 StoragePath = "/var/lib/eulabeia/director/storage"
 

--- a/director/scan/scan.go
+++ b/director/scan/scan.go
@@ -46,6 +46,7 @@ func (t scanAggregate) Start(s cmds.Start) (messages.Event, *info.Failure, error
 		return nil, info.GetFailureResponse(s.Message, "scan", s.ID), nil
 	}
 
+	log.Printf("Starting scan (%s) on sensor (%s)", s.ID, scan.Sensor)
 	return &cmds.Start{
 		Identifier: messages.Identifier{
 			Message: messages.NewMessage(fmt.Sprintf("start.scan.%s", scan.Sensor), s.MessageID, s.GroupID),

--- a/sensor/handler/handler.go
+++ b/sensor/handler/handler.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 
 	"github.com/greenbone/eulabeia/connection"
+	"github.com/greenbone/eulabeia/messages"
 	"github.com/greenbone/eulabeia/messages/cmds"
 	"github.com/greenbone/eulabeia/messages/info"
 )
@@ -37,11 +38,17 @@ func (handler StartStop) On(topic string, message []byte) (*connection.SendRespo
 	if err != nil {
 		return nil, err
 	}
-	switch msg.Type {
-	case "scan.start":
-		handler.StartChan <- msg.ID
-	case "scan.stop":
-		handler.StopChan <- msg.ID
+	mt, err := messages.ParseMessageType(msg.Type)
+	if err != nil {
+		return nil, err
+	}
+	if mt.Aggregate == "scan" {
+		switch mt.Function {
+		case "start":
+			handler.StartChan <- msg.ID
+		case "stop":
+			handler.StopChan <- msg.ID
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Add hardcoded sensor.Id because container host vary.
Enhanced example-client to stop on `scan.status` for `mega_scan_123`.
Change sensor to parse the messagetype instead of switch case.