### PR TITLE
Change: instead of using community feed create test.nasl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ stop-director:
 start-sensor:
 	docker volume create eulabeia_redis_socket
 	docker volume create eulabeia_feed
-	docker pull greenbone/community-feed-vts:latest
 	docker run -d --rm -v eulabeia_redis_socket:/run/redis --name eulabeia_redis $(REPOSITORY)/eulabeia-redis
-	docker run -d --rm -v eulabeia_feed:/opt/$(REPOSITORY)/feed/plugins greenbone/community-feed-vts:latest echo ""
 	$(MQTT_CONTAINER) -d -v eulabeia_feed:/var/lib/openvas/feed/plugins -v eulabeia_redis_socket:/run/redis --name eulabeia_sensor $(REPOSITORY)/eulabeia-sensor
+	docker cp test.nasl eulabeia_sensor:/var/lib/openvas/feed/plugins/test.nasl
+	docker cp plugin_feed_info.inc eulabeia_sensor:/var/lib/openvas/feed/plugins/plugin_feed_info.inc
 
 stop-sensor:
 	docker stop eulabeia_sensor

--- a/cmd/example-client/main.go
+++ b/cmd/example-client/main.go
@@ -145,7 +145,7 @@ func MegaScan(msg info.IDInfo, _ []byte) *connection.SendResponse {
 						},
 					},
 					Group: map[string]string{
-						"family": "foobar",
+						"family": "my test family",
 					},
 				},
 				Exclude:  []string{"exclude1"},

--- a/plugin_feed_info.inc
+++ b/plugin_feed_info.inc
@@ -1,0 +1,5 @@
+PLUGIN_SET = "202001010002";
+PLUGIN_FEED = "Greenbone SCM Feed";
+FEED_VENDOR = "Greenbone Networks GmbH";
+FEED_HOME = "N/A";
+FEED_NAME = "SCM";

--- a/test.nasl
+++ b/test.nasl
@@ -1,0 +1,27 @@
+if(description)
+{
+  script_oid("1.3.6.1.4.1.25623.1.0.90022");
+  script_version("2019-11-10T15:30:28+0000");
+  script_name("mqtt test");
+  script_category(ACT_INIT);
+  script_family("my test family");  
+  script_tag(name:"some", value:"tag");
+  script_tag(name:"last_modification", value:"2019-11-10 15:30:28 +0000 (Tue, 10 Nov 2020)");
+  script_tag(name:"creation_date", value:"2015-03-27 12:00:00 +0100 (Fri, 27 Mar 2015)");
+  script_tag(name:"cvss_base", value:"0.0");
+  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
+  script_tag(name:"summary", value:"Report functions were used.");
+  script_tag(name:"qod_type", value:"remote_app");
+
+  exit(0);
+}
+
+sec_msg = "this is a security message";
+log_msg = "this is a log message";
+err_msg = "this is a error message";
+
+security_message(data:sec_msg);
+log_message(data:log_msg);
+error_message(data:err_msg);
+
+exit(0);


### PR DESCRIPTION
Due to the dependencies within the nasl script of the community feed we
would need to add a lot of programs to run them.

To make testing easier it is better to provide simple nasl plugins by
ourself.
test.nasl plugin sends:
- security_message(data:sec_msg);
- log_message(data:log_msg);
- error_message(data:err_msg);

with that we can verify the result handling within eulabeia.