### PR TITLE
 Add: result handling within scan_progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ format:
 	clang-format -i --style=file ./c/libeulabeia/include/eulabeia/*.h
 	clang-format -i --style=file ./c/example/*.c
 
+c-library:
+	cmake -S c/libeulabeia/ -B c/libeulabeia/build
+	cmake --build c/libeulabeia/build
+	cmake --build c/libeulabeia/build -- test
+
+c-examples:
+	cmake -S c/example/ -B c/example/build
+	cmake --build c/example/build
 
 check:
 	go vet ./...

--- a/c/libeulabeia/include/eulabeia/json.h
+++ b/c/libeulabeia/include/eulabeia/json.h
@@ -214,8 +214,8 @@ char *eulabeia_target_message_to_json(const struct EulabeiaMessage *msg,
  *  -3,-4 on setting value failure
  */
 int eulabeia_json_scan_result(JsonObject *obj,
-			  struct EulabeiaMessage *msg,
-			       struct EulabeiaScanResult **scan_result);
+			      struct EulabeiaMessage *msg,
+			      struct EulabeiaScanResult **scan_result);
 
 /*
  * @brief transforms EulabeiaScanResult to json string.

--- a/c/libeulabeia/include/eulabeia/types.h
+++ b/c/libeulabeia/include/eulabeia/types.h
@@ -93,7 +93,7 @@ enum eulabeia_crud_state {
 	X(EULABEIA_CMD_MODIFY, modify, cmd)                                    \
 	X(EULABEIA_INFO_MODIFIED, modified, info)                              \
 	X(EULABEIA_INFO_STATUS, status, info)                                  \
-	X(EULABEIA_INFO_SCAN_RESULT, result, info)                                  \
+	X(EULABEIA_INFO_SCAN_RESULT, result, info)                             \
 	X(EULABEIA_INFO_FAILURE, failure, info)
 
 //@brief enum generated of first parameter of EULABEIA_MESSAGE_TYPES
@@ -325,9 +325,79 @@ void eulabeia_ports_destroy(struct EulabeiaPorts **ports);
 /*
  * @brief destroys an EulabeiaScanResult
  *
- * @param[out] scan_result, the EulabeiaScanResult to be freed. Sets *scan_result to NULL.
+ * @param[out] scan_result, the EulabeiaScanResult to be freed. Sets
+ * *scan_result to NULL.
  */
 void eulabeia_scan_result_destroy(struct EulabeiaScanResult **scan_result);
+
+/*
+ * @brief destroys an EulabeiaScanProgress
+ *
+ * @param[out] scan_progress, the EulabeiaScanProgress to be freed. Sets
+ * *scan_progress to NULL.
+ */
+void eulabeia_scan_progress_destroy(
+    struct EulabeiaScanProgress **scan_progress);
+
+/*
+ * @brief builds an message_type char array based on message_type and aggregate
+ *
+ * @param[in] message_type the eulabeia_message_type
+ * @param[in] aggregata the eulabeia_aggregate
+ *
+ * @return a char array according to the definition of a message_type
+ * (message_type.aggregate)
+ */
+char *eulabeia_message_type(enum eulabeia_message_type message_type,
+			    enum eulabeia_aggregate aggregate);
+
+/*
+ * @brief initializes a valud EulabeiaMessage based on message_type, aggregate
+ * and may group_id
+ *
+ * @param[in] message_type the eulabeia_message_type
+ * @param[in] aggregata the eulabeia_aggregate
+ * @param[in] group_id on NULL a new uuid as group_id will be set otherwise the
+ * message will contain the given group_id
+ * @return an EulabeiaMessage or NULL on failure.
+ */
+struct EulabeiaMessage *
+eulabeia_initialize_message(enum eulabeia_message_type message_type,
+			    enum eulabeia_aggregate aggregate,
+			    char *group_id);
+
+/*
+ * @brief translate given eulabeia_scan_state to a char representation
+ *
+ * @param[in] scan_state to translate
+ * @return char array representation of given scan_state
+ */
+char *eulabeia_scan_state_to_str(enum eulabeia_scan_state srs);
+
+/*
+ * @brief translate given eulabeia_scan_state to a event type char array.
+ *
+ * The event type is used to calculate topic based on if given message_type is
+ * an info or cmd event.
+ *
+ * @param[in] scan_state to translate
+ * @return char array representation of the event type (cmd or info)
+ */
+char *eulabeia_message_type_to_event_type(enum eulabeia_message_type mt);
+
+/*
+ * @brief translate given eulabeia_message_type to a char representation
+ *
+ * @param[in] message_type to translate
+ * @return char array representation of given message_type
+ */
+char *eulabeia_message_type_to_str(enum eulabeia_message_type mt);
+
+/*
+ * @brief translate given eulabeia_aggregate to a char representation
+ *
+ * @param[in] aggregate to translate
+ * @return char array representation of given aggregate
 /*
  * @brief builds an message_type char array based on message_type and aggregate
  *

--- a/c/libeulabeia/src/eulabeia_json.c
+++ b/c/libeulabeia/src/eulabeia_json.c
@@ -326,7 +326,6 @@ void builder_add_result(JsonBuilder *builder,
 	json_builder_add_string_value(builder, result->uri);
 }
 
-
 // expects a builder with an open object, internal use
 void builder_add_target(JsonBuilder *builder,
 			const struct EulabeiaTarget *target,

--- a/c/libeulabeia/src/eulabeia_types.c
+++ b/c/libeulabeia/src/eulabeia_types.c
@@ -182,34 +182,54 @@ void eulabeia_ports_destroy(struct EulabeiaPorts **ports)
 	*ports = NULL;
 }
 
+void free_scan_result_data(struct EulabeiaScanResult *scan_result)
+{
+	if ((scan_result)->result_type)
+		free((scan_result)->result_type);
+	if ((scan_result)->host_ip)
+		free((scan_result)->host_ip);
+	if ((scan_result)->host_name)
+		free((scan_result)->host_name);
+	if ((scan_result)->oid)
+		free((scan_result)->oid);
+	if ((scan_result)->id)
+		free((scan_result)->id);
+	if ((scan_result)->uri)
+		free((scan_result)->uri);
+	if ((scan_result)->value)
+		free((scan_result)->value);
+	if ((scan_result)->port)
+		free((scan_result)->port);
+}
+
 void eulabeia_scan_result_destroy(struct EulabeiaScanResult **scan_result)
 {
 	if (scan_result == NULL || *scan_result == NULL)
 		return;
 
-	if ((*scan_result)->message)
-		eulabeia_message_destroy(&(*scan_result)->message);
-	if ((*scan_result)->result_type)
-		free((*scan_result)->result_type);
-	if ((*scan_result)->host_ip)
-		free((*scan_result)->host_ip);
-	if ((*scan_result)->host_name)
-		free((*scan_result)->host_name);
-	if ((*scan_result)->oid)
-		free((*scan_result)->oid);
-	if ((*scan_result)->id)
-		free((*scan_result)->id);
-	if ((*scan_result)->uri)
-		free((*scan_result)->uri);
-	if ((*scan_result)->value)
-		free((*scan_result)->value);
-	if ((*scan_result)->port)
-		free((*scan_result)->port);
+	free_scan_result_data(*scan_result);
 
 	free(*scan_result);
 	*scan_result = NULL;
 }
 
+void eulabeia_scan_progress_destroy(struct EulabeiaScanProgress **scan_progress)
+{
+	int i;
+	struct EulabeiaScanResult *ptr;
+	if (scan_progress == NULL || *scan_progress == NULL)
+		return;
+	if ((*scan_progress)->results != NULL &&
+	    (*scan_progress)->results->results != NULL) {
+		for (i = 0; i < (*scan_progress)->results->len; i++) {
+			ptr = (*scan_progress)->results->results + i;
+			free_scan_result_data(ptr);
+		}
+		free((*scan_progress)->results->results);
+	}
+	free(*scan_progress);
+	*scan_progress = NULL;
+}
 char *eulabeia_message_type(enum eulabeia_message_type message_type,
 			    enum eulabeia_aggregate aggregate)
 {

--- a/c/libeulabeia/test/CMakeLists.txt
+++ b/c/libeulabeia/test/CMakeLists.txt
@@ -37,9 +37,23 @@ endif()
 add_executable(all_tests src/all.c src/eulabeia_json_tests src/start_scan.c src/scan_porgress.c)
 target_link_libraries(all_tests ${NUMA} ${CGREEN_LIBRARIES} ${TEST_LINKER_WRAP_OPTIONS} Eulabeia::eulabeia)
 
-add_test(NAME test_start_scan_fail
+add_test(NAME start_scan_fail
     COMMAND all_tests start_scan_returns_error_on_publish_fail)
-add_test(NAME test_start_scan_success
+add_test(NAME start_scan_success
     COMMAND all_tests start_scan_success)
-add_test(NAME test_progress_fail
+add_test(NAME scan_progress_fail
     COMMAND all_tests scan_progress_failures)
+add_test(NAME scan_progress_success
+    COMMAND all_tests scan_progress_success)
+add_test(NAME json_create_object_success
+	COMMAND all_tests create_object_success)
+add_test(NAME json_create_message_success
+	COMMAND all_tests create_message_success)
+add_test(NAME json_create_failure_success
+	COMMAND all_tests create_failure_success)
+add_test(NAME json_create_hosts_success
+	COMMAND all_tests create_hosts_success)
+add_test(NAME json_plugins_create_success
+	COMMAND all_tests plugins_create_success)
+add_test(NAME json_ports_create_success
+	COMMAND all_tests ports_create_success)

--- a/c/libeulabeia/test/src/eulabeia_json_tests.c
+++ b/c/libeulabeia/test/src/eulabeia_json_tests.c
@@ -204,8 +204,7 @@ Ensure(Eulabeia_json, create_object_success)
 	JsonNode *j_node = NULL;
 	JsonObject *j_obj;
 
-	assert_equal(eulabeia_json_object(g_json_str, &j_node, &j_obj),
-		     0);
+	assert_equal(eulabeia_json_object(g_json_str, &j_node, &j_obj), 0);
 	assert_not_equal(j_node, NULL);
 	assert_not_equal(j_obj, NULL);
 


### PR DESCRIPTION
 Add: result handling within scan_progress

To store the results within a client they need to be stored. To do that
those scan.results are stored within EulabeiaScanProgress on
scan_progress handling.