### PR TITLE
Add compiler flags and fix warnings

### DIFF
--- a/c/libeulabeia/CMakeLists.txt
+++ b/c/libeulabeia/CMakeLists.txt
@@ -21,6 +21,7 @@ project(
   libeulabeia
   VERSION 1.0.0
   LANGUAGES C)
+
 # define library before find packages to allow import of autotools projects
 # (glib)
 add_library(eulabeia src/eulabeia_types.c src/eulabeia_json.c
@@ -50,18 +51,8 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE {CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_compile_options(
-  eulabeia
-  PRIVATE
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-    -Wall
-    -Wextra
-    -Werror
-    -Wsequence-point
-    -Wstrict-prototypes
-    -Wshadow
-    -Wmissing-prototypes
-    -Wpedantic>)
+# Compiler flags.
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wsequence-point -Wstrict-prototypes -Wshadow -Wmissing-prototypes -Wpedantic -fpic")
 
 # Installation instructions
 

--- a/c/libeulabeia/src/eulabeia_client.c
+++ b/c/libeulabeia/src/eulabeia_client.c
@@ -35,6 +35,11 @@ volatile int already_connected =
 static int
 default_publish(const char *topic, const char *message, void *context)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+	(void *)context;
+#pragma GCC diagnostic pop
+
 	return mqtt_publish(topic, message);
 }
 
@@ -44,6 +49,10 @@ static int default_retrieve(char **topic,
 			    int *payload_len,
 			    void *context)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+	(void *)context;
+#pragma GCC diagnostic pop
 	return mqtt_retrieve_message(topic, topic_len, payload, payload_len);
 }
 
@@ -101,8 +110,8 @@ int eulabeia_json_object(const char *payload,
 }
 
 static int eulabeia_scan_progress_status(const char *id,
-				  const struct EulabeiaStatus *status,
-				  struct EulabeiaScanProgress *progress)
+					 const struct EulabeiaStatus *status,
+					 struct EulabeiaScanProgress *progress)
 {
 	int rc = -6;
 	if (strcmp(id, status->id) != 0) {
@@ -241,14 +250,14 @@ char *eulabeia_calculate_topic(enum eulabeia_message_type mt,
 // @return 0 on success, -1 when either ec or data is null, -2 when data in
 // invalid; -3 when data could not be published
 static int publish_message(const struct EulabeiaClient *ec,
-		    enum eulabeia_message_type mt,
-		    enum eulabeia_aggregate a,
-		    char *group_id,
-		    void *data,
-		    const char *destination,
-		    verify_data verifier,
-		    to_json tj,
-		    const int modify)
+			   enum eulabeia_message_type mt,
+			   enum eulabeia_aggregate a,
+			   char *group_id,
+			   void *data,
+			   const char *destination,
+			   verify_data verifier,
+			   to_json tj,
+			   const int modify)
 {
 	char *json, *topic;
 	int rc;

--- a/c/libeulabeia/src/eulabeia_client.c
+++ b/c/libeulabeia/src/eulabeia_client.c
@@ -100,7 +100,7 @@ int eulabeia_json_object(const char *payload,
 	return 0;
 }
 
-int eulabeia_scan_progress_status(const char *id,
+static int eulabeia_scan_progress_status(const char *id,
 				  const struct EulabeiaStatus *status,
 				  struct EulabeiaScanProgress *progress)
 {
@@ -240,7 +240,7 @@ char *eulabeia_calculate_topic(enum eulabeia_message_type mt,
 //
 // @return 0 on success, -1 when either ec or data is null, -2 when data in
 // invalid; -3 when data could not be published
-int publish_message(const struct EulabeiaClient *ec,
+static int publish_message(const struct EulabeiaClient *ec,
 		    enum eulabeia_message_type mt,
 		    enum eulabeia_aggregate a,
 		    char *group_id,
@@ -280,7 +280,7 @@ exit:
 }
 
 // @brief verifies scan_data according to @see verify_data.
-int verify_scan_data(struct EulabeiaScan *scan)
+static int verify_scan_data(struct EulabeiaScan *scan)
 {
 	if (scan == NULL) {
 		return -1;
@@ -292,7 +292,7 @@ int verify_scan_data(struct EulabeiaScan *scan)
 }
 
 // @brief verifies target_data according to @see verify_data.
-int verify_target_data(struct EulabeiaTarget *target)
+static int verify_target_data(struct EulabeiaTarget *target)
 {
 	if (target == NULL) {
 		return -1;

--- a/c/libeulabeia/src/eulabeia_json.c
+++ b/c/libeulabeia/src/eulabeia_json.c
@@ -280,7 +280,7 @@ int eulabeia_json_ports(JsonArray *arr, struct EulabeiaPorts **ports)
 }
 
 static void builder_add_plugins(JsonBuilder *builder,
-			 const struct EulabeiaPlugins *plugins)
+				const struct EulabeiaPlugins *plugins)
 {
 	unsigned int i;
 	json_builder_begin_object(builder);
@@ -296,7 +296,8 @@ static void builder_add_plugins(JsonBuilder *builder,
 	json_builder_end_object(builder);
 }
 
-static void builder_add_ports(JsonBuilder *builder, const struct EulabeiaPorts *ports)
+static void builder_add_ports(JsonBuilder *builder,
+			      const struct EulabeiaPorts *ports)
 {
 	unsigned int i;
 	json_builder_begin_array(builder);
@@ -306,7 +307,8 @@ static void builder_add_ports(JsonBuilder *builder, const struct EulabeiaPorts *
 	json_builder_end_array(builder);
 }
 
-static void builder_add_hosts(JsonBuilder *builder, const struct EulabeiaHosts *hosts)
+static void builder_add_hosts(JsonBuilder *builder,
+			      const struct EulabeiaHosts *hosts)
 {
 	unsigned int i;
 	json_builder_begin_array(builder);
@@ -317,7 +319,7 @@ static void builder_add_hosts(JsonBuilder *builder, const struct EulabeiaHosts *
 }
 
 static void builder_add_result(JsonBuilder *builder,
-			const struct EulabeiaScanResult *result)
+			       const struct EulabeiaScanResult *result)
 {
 	json_builder_set_member_name(builder, "result_type");
 	json_builder_add_string_value(builder, result->result_type);
@@ -338,7 +340,7 @@ static void builder_add_result(JsonBuilder *builder,
 }
 
 static void builder_add_status(JsonBuilder *builder,
-			const struct EulabeiaStatus *status)
+			       const struct EulabeiaStatus *status)
 {
 
 	json_builder_set_member_name(builder, "id");
@@ -350,8 +352,8 @@ static void builder_add_status(JsonBuilder *builder,
 
 // expects a builder with an open object, internal use
 static void builder_add_target(JsonBuilder *builder,
-			const struct EulabeiaTarget *target,
-			const int modify)
+			       const struct EulabeiaTarget *target,
+			       const int modify)
 {
 	if (target->id) {
 		json_builder_set_member_name(builder, "id");
@@ -394,9 +396,9 @@ static void builder_add_target(JsonBuilder *builder,
 	}
 }
 
-static  void builder_add_scan(JsonBuilder *builder,
-		      const struct EulabeiaScan *scan,
-		      const int modify)
+static void builder_add_scan(JsonBuilder *builder,
+			     const struct EulabeiaScan *scan,
+			     const int modify)
 {
 	if (scan->id) {
 		json_builder_set_member_name(builder, "id");
@@ -423,7 +425,7 @@ static  void builder_add_scan(JsonBuilder *builder,
 }
 
 static void builder_add_message(JsonBuilder *builder,
-			 const struct EulabeiaMessage *msg)
+				const struct EulabeiaMessage *msg)
 {
 	json_builder_set_member_name(builder, "message_id");
 	json_builder_add_string_value(builder, msg->id);
@@ -436,7 +438,7 @@ static void builder_add_message(JsonBuilder *builder,
 }
 
 static void builder_add_failure(JsonBuilder *builder,
-			 const struct EulabeiaFailure *failure)
+				const struct EulabeiaFailure *failure)
 {
 	json_builder_set_member_name(builder, "id");
 	json_builder_add_string_value(builder, failure->id);

--- a/c/libeulabeia/src/eulabeia_json.c
+++ b/c/libeulabeia/src/eulabeia_json.c
@@ -33,15 +33,14 @@ static int json_object_get_and_assign_string(JsonObject *obj,
 					     char **value)
 {
 	const char *jvalue;
-	unsigned int len;
+
 	if ((jvalue = json_object_get_string_member(obj, key)) == NULL) {
 		return 1;
 	}
-	len = strlen(jvalue);
-	if ((*value = calloc(1, len)) == NULL)
+
+	if ((*value = g_strdup(jvalue)) == NULL)
 		return -1;
-	if (strncpy(*value, jvalue, len) == NULL)
-		return -2;
+
 	return 0;
 }
 

--- a/c/libeulabeia/src/eulabeia_json.c
+++ b/c/libeulabeia/src/eulabeia_json.c
@@ -74,7 +74,6 @@ int eulabeia_json_failure(JsonObject *obj,
 			  struct EulabeiaMessage *msg,
 			  struct EulabeiaFailure **failure)
 {
-	int rc;
 	enum eulabeia_message_type failure_type;
 	if (msg == NULL || msg->type == NULL)
 		return -1;
@@ -214,7 +213,6 @@ int eulabeia_json_status(JsonObject *obj,
 
 int eulabeia_json_hosts(JsonArray *arr, struct EulabeiaHosts **hosts)
 {
-	struct EulabeiaHost *h;
 	const char *a;
 	unsigned int arr_len;
 	if (*hosts == NULL) {
@@ -227,7 +225,7 @@ int eulabeia_json_hosts(JsonArray *arr, struct EulabeiaHosts **hosts)
 	}
 	(*hosts)->cap = arr_len;
 	(*hosts)->len = arr_len;
-	for (int index = 0; index < arr_len; index++) {
+	for (unsigned int index = 0; index < arr_len; index++) {
 		a = json_array_get_string_element(arr, index);
 		(*hosts)->hosts[index].address = g_strdup(a);
 	}
@@ -239,7 +237,6 @@ int eulabeia_json_hosts(JsonArray *arr, struct EulabeiaHosts **hosts)
 
 int eulabeia_json_plugins(JsonArray *arr, struct EulabeiaPlugins **plugins)
 {
-	struct EulabeiaPlugin *h;
 	const char *a;
 	unsigned int arr_len;
 	if (*plugins == NULL) {
@@ -252,7 +249,7 @@ int eulabeia_json_plugins(JsonArray *arr, struct EulabeiaPlugins **plugins)
 	}
 	(*plugins)->cap = arr_len;
 	(*plugins)->len = arr_len;
-	for (int index = 0; index < arr_len; index++) {
+	for (unsigned int index = 0; index < arr_len; index++) {
 		a = json_array_get_string_element(arr, index);
 		(*plugins)->plugins[index].oid = g_strdup(a);
 	}
@@ -262,7 +259,6 @@ int eulabeia_json_plugins(JsonArray *arr, struct EulabeiaPlugins **plugins)
 
 int eulabeia_json_ports(JsonArray *arr, struct EulabeiaPorts **ports)
 {
-	struct EulabeiaPort *h;
 	const char *a;
 	unsigned int arr_len;
 	if (*ports == NULL) {
@@ -275,17 +271,18 @@ int eulabeia_json_ports(JsonArray *arr, struct EulabeiaPorts **ports)
 	}
 	(*ports)->cap = arr_len;
 	(*ports)->len = arr_len;
-	for (int index = 0; index < arr_len; index++) {
+	for (unsigned int index = 0; index < arr_len; index++) {
 		a = json_array_get_string_element(arr, index);
 		(*ports)->ports[index].port = g_strdup(a);
 	}
 
 	return 0;
 }
-void builder_add_plugins(JsonBuilder *builder,
+
+static void builder_add_plugins(JsonBuilder *builder,
 			 const struct EulabeiaPlugins *plugins)
 {
-	int i;
+	unsigned int i;
 	json_builder_begin_object(builder);
 	json_builder_set_member_name(builder, "single_vts");
 	json_builder_begin_array(builder);
@@ -299,9 +296,9 @@ void builder_add_plugins(JsonBuilder *builder,
 	json_builder_end_object(builder);
 }
 
-void builder_add_ports(JsonBuilder *builder, const struct EulabeiaPorts *ports)
+static void builder_add_ports(JsonBuilder *builder, const struct EulabeiaPorts *ports)
 {
-	int i;
+	unsigned int i;
 	json_builder_begin_array(builder);
 	for (i = 0; i < ports->len; i++) {
 		json_builder_add_string_value(builder, ports->ports[i].port);
@@ -309,9 +306,9 @@ void builder_add_ports(JsonBuilder *builder, const struct EulabeiaPorts *ports)
 	json_builder_end_array(builder);
 }
 
-void builder_add_hosts(JsonBuilder *builder, const struct EulabeiaHosts *hosts)
+static void builder_add_hosts(JsonBuilder *builder, const struct EulabeiaHosts *hosts)
 {
-	int i;
+	unsigned int i;
 	json_builder_begin_array(builder);
 	for (i = 0; i < hosts->len; i++) {
 		json_builder_add_string_value(builder, hosts->hosts[i].address);
@@ -319,7 +316,7 @@ void builder_add_hosts(JsonBuilder *builder, const struct EulabeiaHosts *hosts)
 	json_builder_end_array(builder);
 }
 
-void builder_add_result(JsonBuilder *builder,
+static void builder_add_result(JsonBuilder *builder,
 			const struct EulabeiaScanResult *result)
 {
 	json_builder_set_member_name(builder, "result_type");
@@ -340,7 +337,7 @@ void builder_add_result(JsonBuilder *builder,
 	json_builder_add_string_value(builder, result->uri);
 }
 
-void builder_add_status(JsonBuilder *builder,
+static void builder_add_status(JsonBuilder *builder,
 			const struct EulabeiaStatus *status)
 {
 
@@ -352,7 +349,7 @@ void builder_add_status(JsonBuilder *builder,
 }
 
 // expects a builder with an open object, internal use
-void builder_add_target(JsonBuilder *builder,
+static void builder_add_target(JsonBuilder *builder,
 			const struct EulabeiaTarget *target,
 			const int modify)
 {
@@ -397,7 +394,7 @@ void builder_add_target(JsonBuilder *builder,
 	}
 }
 
-void builder_add_scan(JsonBuilder *builder,
+static  void builder_add_scan(JsonBuilder *builder,
 		      const struct EulabeiaScan *scan,
 		      const int modify)
 {
@@ -425,7 +422,7 @@ void builder_add_scan(JsonBuilder *builder,
 	}
 }
 
-void builder_add_message(JsonBuilder *builder,
+static void builder_add_message(JsonBuilder *builder,
 			 const struct EulabeiaMessage *msg)
 {
 	json_builder_set_member_name(builder, "message_id");
@@ -438,7 +435,7 @@ void builder_add_message(JsonBuilder *builder,
 	json_builder_add_int_value(builder, msg->created);
 }
 
-void builder_add_failure(JsonBuilder *builder,
+static void builder_add_failure(JsonBuilder *builder,
 			 const struct EulabeiaFailure *failure)
 {
 	json_builder_set_member_name(builder, "id");
@@ -447,7 +444,7 @@ void builder_add_failure(JsonBuilder *builder,
 	json_builder_add_string_value(builder, failure->error);
 }
 
-char *json_builder_to_str(JsonBuilder *builder)
+static char *json_builder_to_str(JsonBuilder *builder)
 {
 	char *json_str;
 	JsonGenerator *gen;

--- a/c/libeulabeia/src/eulabeia_types.c
+++ b/c/libeulabeia/src/eulabeia_types.c
@@ -131,7 +131,7 @@ void eulabeia_status_destroy(struct EulabeiaStatus **status)
 void eulabeia_hosts_destroy(struct EulabeiaHosts **hosts)
 {
 	struct EulabeiaHost *p_index, *p_orig;
-	unsigned int i;
+	unsigned int i = 0;
 
 	if (hosts == NULL || *hosts == NULL) {
 		g_warning("hosts == NULL || *hosts == NULL");
@@ -153,7 +153,7 @@ void eulabeia_hosts_destroy(struct EulabeiaHosts **hosts)
 
 void eulabeia_plugins_destroy(struct EulabeiaPlugins **plugins)
 {
-	unsigned int i;
+	unsigned int i = 0;
 	struct EulabeiaPlugin *p_index, *p_orig;
 
 	if (plugins == NULL || *plugins == NULL)
@@ -175,7 +175,7 @@ void eulabeia_plugins_destroy(struct EulabeiaPlugins **plugins)
 
 void eulabeia_ports_destroy(struct EulabeiaPorts **ports)
 {
-	unsigned int i;
+	unsigned int i = 0;
 	struct EulabeiaPort *p_index, *p_orig;
 
 	if (ports == NULL || *ports == NULL)

--- a/c/libeulabeia/src/eulabeia_types.c
+++ b/c/libeulabeia/src/eulabeia_types.c
@@ -131,7 +131,7 @@ void eulabeia_status_destroy(struct EulabeiaStatus **status)
 void eulabeia_hosts_destroy(struct EulabeiaHosts **hosts)
 {
 	struct EulabeiaHost *p_index, *p_orig;
-	int i;
+	unsigned int i;
 
 	if (hosts == NULL || *hosts == NULL) {
 		g_warning("hosts == NULL || *hosts == NULL");
@@ -153,7 +153,7 @@ void eulabeia_hosts_destroy(struct EulabeiaHosts **hosts)
 
 void eulabeia_plugins_destroy(struct EulabeiaPlugins **plugins)
 {
-	int i;
+	unsigned int i;
 	struct EulabeiaPlugin *p_index, *p_orig;
 
 	if (plugins == NULL || *plugins == NULL)
@@ -175,7 +175,7 @@ void eulabeia_plugins_destroy(struct EulabeiaPlugins **plugins)
 
 void eulabeia_ports_destroy(struct EulabeiaPorts **ports)
 {
-	int i;
+	unsigned int i;
 	struct EulabeiaPort *p_index, *p_orig;
 
 	if (ports == NULL || *ports == NULL)
@@ -195,7 +195,7 @@ void eulabeia_ports_destroy(struct EulabeiaPorts **ports)
 	*ports = NULL;
 }
 
-void free_scan_result_data(struct EulabeiaScanResult *scan_result)
+static void free_scan_result_data(struct EulabeiaScanResult *scan_result)
 {
 	if ((scan_result)->result_type)
 		free((scan_result)->result_type);
@@ -228,7 +228,7 @@ void eulabeia_scan_result_destroy(struct EulabeiaScanResult **scan_result)
 
 void eulabeia_scan_progress_destroy(struct EulabeiaScanProgress **scan_progress)
 {
-	int i;
+	unsigned int i;
 	struct EulabeiaScanResult *ptr;
 	if (scan_progress == NULL || *scan_progress == NULL)
 		return;

--- a/c/libeulabeia/test/src/all.c
+++ b/c/libeulabeia/test/src/all.c
@@ -18,10 +18,9 @@
  */
 
 #include <cgreen/cgreen.h>
-
-TestSuite *publish_tests();
-TestSuite *progress_tests();
-TestSuite *eulabeia_json_tests();
+TestSuite *publish_tests(void);
+TestSuite *progress_tests(void);
+TestSuite *eulabeia_json_tests(void);
 
 int main(int argc, char **argv)
 {

--- a/c/libeulabeia/test/src/eulabeia_json_tests.c
+++ b/c/libeulabeia/test/src/eulabeia_json_tests.c
@@ -161,7 +161,7 @@ void __wrap_free(void *p)
 /**
  * @brief init global memory size counters and use mem wrapper
  */
-void activate_mem_tracking()
+static void activate_mem_tracking(void)
 {
 #if defined(HAVE_NUMA) && defined(CGREEN_NO_FORK)
 	g_alloc_cnt = 0;
@@ -175,7 +175,7 @@ void activate_mem_tracking()
  * @brief init global memory size counters and use mem wrapper
  *
  */
-void deactivate_mem_tracking()
+static void deactivate_mem_tracking(void)
 {
 #if defined(HAVE_NUMA) && defined(CGREEN_NO_FORK)
 	g_alloc_cnt = 0;
@@ -185,7 +185,9 @@ void deactivate_mem_tracking()
 #endif
 }
 
-void ensure_alloc_equal_free(const char *call_func)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+static void ensure_alloc_equal_free(const char *call_func)
 {
 #if defined(HAVE_NUMA) && defined(CGREEN_NO_FORK)
 	g_warning("%s: (%d:%d)", call_func, g_alloc_cnt, g_free_cnt);
@@ -198,6 +200,7 @@ void ensure_alloc_equal_free(const char *call_func)
 	    g_free_cnt);
 #endif
 }
+#pragma GCC diagnostic pop
 
 Ensure(Eulabeia_json, create_object_success)
 {
@@ -295,7 +298,6 @@ clean_exit:
 Ensure(Eulabeia_json, create_hosts_success)
 {
 	int err;
-	int rc;
 	JsonNode *j_node = NULL;
 	JsonObject *j_obj;
 	JsonArray *host_arr;
@@ -331,7 +333,6 @@ clean_exit:
 Ensure(Eulabeia_json, plugins_create_success)
 {
 	int err;
-	int rc;
 	JsonObject *j_obj;
 	JsonArray *plugin_arr;
 
@@ -403,6 +404,8 @@ clean_exit:
 		json_node_free(j_node);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
 TestSuite *eulabeia_json_tests()
 {
 	TestSuite *suite = create_test_suite();
@@ -414,3 +417,4 @@ TestSuite *eulabeia_json_tests()
 	add_test_with_context(suite, Eulabeia_json, ports_create_success);
 	return suite;
 }
+#pragma GCC diagnostic pop

--- a/c/libeulabeia/test/src/scan_porgress.c
+++ b/c/libeulabeia/test/src/scan_porgress.c
@@ -31,11 +31,15 @@ AfterEach(Progress) {}
 #define SUCCESS 1
 #define FAILURE 0
 
-int progress(const char *topic, const char *message, void *context)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+static int progress(const char *topic, const char *message, void *context)
 {
 	int *c = (int *)context;
 	return *c == SUCCESS ? 0 : -42;
 }
+#pragma GCC diagnostic pop
 
 Ensure(Progress, scan_progress_failures)
 {
@@ -191,6 +195,8 @@ Ensure(Progress, scan_progress_success)
 	eulabeia_scan_progress_destroy(&progress);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
 TestSuite *progress_tests()
 {
 	TestSuite *suite = create_test_suite();
@@ -198,3 +204,4 @@ TestSuite *progress_tests()
 	add_test_with_context(suite, Progress, scan_progress_success);
 	return suite;
 }
+#pragma GCC diagnostic pop

--- a/c/libeulabeia/test/src/start_scan.c
+++ b/c/libeulabeia/test/src/start_scan.c
@@ -29,17 +29,20 @@ AfterEach(Publish) {}
 #define SUCCESS 1
 #define FAILURE 0
 
-int publish(const char *topic, const char *message, void *context)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+static int publish(const char *topic, const char *message, void *context)
 {
 	int *c = (int *)context;
 	return *c == SUCCESS ? 0 : -42;
 }
+#pragma GCC diagnostic pop
 
 Ensure(Publish, start_scan_returns_error_on_publish_fail)
 {
 
 	struct EulabeiaClient *ec = calloc(1, sizeof(struct EulabeiaClient));
-	ec->publish = publish;
+	ec->publish = &publish;
 	struct EulabeiaScan *scan = calloc(1, sizeof(struct EulabeiaScan));
 	int fail = FAILURE;
 	ec->context = &fail;
@@ -69,7 +72,7 @@ Ensure(Publish, start_scan_returns_error_on_publish_fail)
 Ensure(Publish, start_scan_success)
 {
 	struct EulabeiaClient *ec = calloc(1, sizeof(struct EulabeiaClient));
-	ec->publish = publish;
+	ec->publish = &publish;
 	struct EulabeiaScan *scan = calloc(1, sizeof(struct EulabeiaScan));
 	int success = SUCCESS;
 	ec->context = &success;
@@ -85,6 +88,8 @@ Ensure(Publish, start_scan_success)
 	free(scan);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
 TestSuite *publish_tests()
 {
 	TestSuite *suite = create_test_suite();
@@ -93,3 +98,4 @@ TestSuite *publish_tests()
 	add_test_with_context(suite, Publish, start_scan_success);
 	return suite;
 }
+#pragma GCC diagnostic pop


### PR DESCRIPTION
**What**:
Add compiler flags.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Enables all compiler's warning messages
-fPIC generates position independent code (PIC) for shared libraries. Allows to be linked into a shared library, like libopenvas_misc.so

Fix error :
```
[ 13%] Linking C shared library libopenvas_misc.so
/usr/bin/ld: /lib/libeulabeia.a(eulabeia_json.c.o): warning: relocation against `pretty_print' in read-only section `.text'
/usr/bin/ld: /lib/libeulabeia.a(eulabeia_json.c.o): relocation R_X86_64_PC32 against symbol `pretty_print' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)