### PR TITLE
Fix: remove mqtt_reset on eulabeia_destroy

### DIFF
--- a/c/libeulabeia/src/eulabeia_client.c
+++ b/c/libeulabeia/src/eulabeia_client.c
@@ -75,10 +75,6 @@ void eulabeia_destroy(struct EulabeiaClient *ec)
 	if (ec == NULL)
 		return;
 	mqtt_unsubscribe(EULABEIA_INFO);
-	if (!already_connected) {
-		g_info("closing mqtt connection");
-		mqtt_reset();
-	}
 	free(ec);
 }
 


### PR DESCRIPTION
Besides the name mqtt_reset isn't meant as a actual reset but a
reconnection method within a subprocess therefore it should not be
called when destroying eulabeia client.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)