### PR TITLE
Install the right staticchek version for the go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GO_BUILD = CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 DOCKER_BUILD = docker build --no-cache --force-rm=true --compress=true
 BROKER_IP = $(or $(shell docker container inspect -f '{{ .NetworkSettings.IPAddress }}' eulabeia_broker), $(echo ""))
 MQTT_CONTAINER = docker run -e "MQTT_SERVER=$(call BROKER_IP):9138" --rm
+GO_MINOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 
 ifndef REPOSITORY
 	REPOSITORY := "greenbone"
@@ -11,9 +12,11 @@ endif
 all: format prepare check test build
 
 prepare:
-	# this only works for Go <1.16 for Go >=1.16 it should be
-	# go install honnef.co/go/tools/cmd/staticcheck@latest
-	go install honnef.co/go/tools/cmd/staticcheck
+	@if [ $(GO_MINOR_VERSION) -gt 15 ]; then\
+		go install honnef.co/go/tools/cmd/staticcheck@latest;\
+	else\
+		go install honnef.co/go/tools/cmd/staticcheck;\
+	fi
 
 format:
 	go mod tidy


### PR DESCRIPTION
**What**:
Install the right staticchek version for the go version<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
honnef.co/go/tools/cmd/staticcheck@latest is for go >= v1.16
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)