### PR TITLE
Add new Host Status type

### DIFF
--- a/c/libeulabeia/include/eulabeia/json.h
+++ b/c/libeulabeia/include/eulabeia/json.h
@@ -270,6 +270,17 @@ eulabeia_scan_result_message_to_json(const struct EulabeiaMessage *msg,
 				     const struct EulabeiaScanResult *result);
 
 /*
+ * @brief transforms EulabeiaScanResult to json string.
+ *
+ * @param[in] msg, the EulabeiaMessage to include
+ * @param[in] scan_result, the scan_result to transform to json string.
+ * @return a json char array or NULL on failure.
+ */
+char *
+eulabeia_host_status_message_to_json(const struct EulabeiaMessage *msg,
+				     const struct EulabeiaHostStatus *status);
+
+/*
  * @brief transforms EulabeiaStatus to json string.
  *
  * @param[in] msg, the EulabeiaMessage to include

--- a/c/libeulabeia/include/eulabeia/types.h
+++ b/c/libeulabeia/include/eulabeia/types.h
@@ -137,7 +137,7 @@ enum eulabeia_aggregate {
 /**
  * @brief defines result types
  *
- * Ressult types are send by the scanner. Most of them are from openvas and
+ * Result types are sent by the scanner. Most of them are from openvas and
  * don't follow the typical eulabeia format.
  *
  * The first value is used as a enum identifier and the second is used to parse
@@ -145,8 +145,6 @@ enum eulabeia_aggregate {
  */
 #define EULABEIA_RESULT_TYPES                                                  \
 	X(EULABEIA_RESULT_TYPE_UNKNOWN, "UNKNOWN")                             \
-	X(EULABEIA_RESULT_TYPE_HOST_COUNT, "HOST_COUNT")                       \
-	X(EULABEIA_RESULT_TYPE_DEADHOST, "DEADHOST")                           \
 	X(EULABEIA_RESULT_TYPE_HOST_START, "HOST_START")                       \
 	X(EULABEIA_RESULT_TYPE_HOST_END, "HOST_END")                           \
 	X(EULABEIA_RESULT_TYPE_ERRMSG, "ERRMSG")                               \
@@ -157,6 +155,30 @@ enum eulabeia_aggregate {
 enum eulabeia_result_type {
 #define X(a, b) a,
 	EULABEIA_RESULT_TYPES
+#undef X
+};
+
+/**
+ * @brief Defines host status types
+ *
+ * Host status are sent by the scanner main process or the host process.
+ * They don't follow the typical eulabeia format.
+ * These messages are mainly for progress calculation and don't end in the
+ * client.
+ *
+ * The first value is used as a enum identifier and the second is used to parse
+ * the enum from and to string. Currently openvas is sending it in uppercase.
+ */
+#define EULABEIA_HOST_STATUS_TYPES                                             \
+	X(EULABEIA_HOST_STATUS_TYPE_UNKNOWN, "HOST_STATUS_UNKNOWN")            \
+	X(EULABEIA_HOST_STATUS_TYPE_HOST_COUNT, "HOST_COUNT")                  \
+	X(EULABEIA_HOST_STATUS_TYPE_DEADHOST, "DEADHOST")                      \
+	X(EULABEIA_HOST_STATUS_TYPE_HOST_STATUS, "HOST_PROGRESS")              \
+	X(EULABEIA_HOST_STATUS_TYPE_ERRMSG, "HOST_ERRMSG")
+
+enum eulabeia_host_status_type {
+#define X(a, b) a,
+	EULABEIA_HOST_STATUS_TYPES
 #undef X
 };
 
@@ -204,6 +226,14 @@ struct EulabeiaScanResult {
 	char *oid;
 	char *value;
 	char *uri;
+};
+
+struct EulabeiaHostStatus {
+	struct EulabeiaMessage *message;
+	enum eulabeia_host_status_type host_status_type; // TODO enum
+	char *host_ip;
+	char *id;
+	char *value;
 };
 
 struct EulabeiaScanResults {
@@ -369,6 +399,14 @@ void eulabeia_ports_destroy(struct EulabeiaPorts **ports);
 void eulabeia_scan_result_destroy(struct EulabeiaScanResult **scan_result);
 
 /*
+ * @brief destroys an EulabeiaHostStatus
+ *
+ * @param[out] scan_result, the EulabeiaScanResult to be freed. Sets
+ * *scan_result to NULL.
+ */
+void eulabeia_host_status_destroy(struct EulabeiaHostStatus **status);
+
+/*
  * @brief destroys an EulabeiaScanProgress
  *
  * @param[out] scan_progress, the EulabeiaScanProgress to be freed. Sets
@@ -486,4 +524,20 @@ char *eulabeia_result_type_to_str(enum eulabeia_result_type rt);
  * @return enum eulabeia_result_type
  */
 enum eulabeia_result_type eulabeia_result_type_from_str(char *s);
+
+/*
+ * @brief translate given eulabeia_host_status_type to a char representation
+ *
+ * @param[in] host_status_type to translate
+ * @return char array representation of given host_status_type
+ */
+char *eulabeia_host_status_type_to_str(enum eulabeia_host_status_type rt);
+
+/*
+ * @brief translate a given char representation to eulabeia_host_status_type
+ *
+ * @param[in] string to translate
+ * @return enum eulabeia_host_status_type
+ */
+enum eulabeia_host_status_type eulabeia_host_status_type_from_str(char *s);
 #endif

--- a/c/libeulabeia/include/eulabeia/types.h
+++ b/c/libeulabeia/include/eulabeia/types.h
@@ -230,7 +230,7 @@ struct EulabeiaScanResult {
 
 struct EulabeiaHostStatus {
 	struct EulabeiaMessage *message;
-	enum eulabeia_host_status_type host_status_type; // TODO enum
+	enum eulabeia_host_status_type host_status_type;
 	char *host_ip;
 	char *id;
 	char *value;

--- a/c/libeulabeia/src/eulabeia_json.c
+++ b/c/libeulabeia/src/eulabeia_json.c
@@ -338,6 +338,19 @@ static void builder_add_result(JsonBuilder *builder,
 	json_builder_add_string_value(builder, result->uri);
 }
 
+static void builder_add_host_status(JsonBuilder *builder,
+			       const struct EulabeiaHostStatus *status)
+{
+	json_builder_set_member_name(builder, "status_type");
+	json_builder_add_int_value(builder, status->host_status_type);
+	json_builder_set_member_name(builder, "host_ip");
+	json_builder_add_string_value(builder, status->host_ip);
+	json_builder_set_member_name(builder, "id");
+	json_builder_add_string_value(builder, status->id);
+	json_builder_set_member_name(builder, "value");
+	json_builder_add_string_value(builder, status->value);
+}
+
 static void builder_add_status(JsonBuilder *builder,
 			       const struct EulabeiaStatus *status)
 {
@@ -522,6 +535,24 @@ eulabeia_scan_result_message_to_json(const struct EulabeiaMessage *msg,
 	json_builder_begin_object(b);
 	builder_add_message(b, msg);
 	builder_add_result(b, result);
+	json_builder_end_object(b);
+
+	json_str = json_builder_to_str(b);
+	g_object_unref(b);
+	return json_str;
+}
+
+char *
+eulabeia_host_status_message_to_json(const struct EulabeiaMessage *msg,
+				     const struct EulabeiaHostStatus *status)
+{
+	JsonBuilder *b;
+	char *json_str;
+	b = json_builder_new();
+
+	json_builder_begin_object(b);
+	builder_add_message(b, msg);
+	builder_add_host_status(b, status);
 	json_builder_end_object(b);
 
 	json_str = json_builder_to_str(b);

--- a/c/libeulabeia/src/eulabeia_types.c
+++ b/c/libeulabeia/src/eulabeia_types.c
@@ -91,6 +91,19 @@ char *eulabeia_result_type_to_str(enum eulabeia_result_type mt)
 	}
 }
 
+char *eulabeia_host_status_type_to_str(enum eulabeia_host_status_type mt)
+{
+	switch (mt) {
+#define X(a, b)                                                                \
+	case a:                                                                \
+		return b;
+		EULABEIA_HOST_STATUS_TYPES
+#undef X
+	default:
+		return NULL;
+	}
+}
+
 void eulabeia_message_destroy(struct EulabeiaMessage **msg)
 {
 	if (*msg == NULL) {
@@ -226,6 +239,27 @@ void eulabeia_scan_result_destroy(struct EulabeiaScanResult **scan_result)
 	*scan_result = NULL;
 }
 
+static void free_host_status_data(struct EulabeiaHostStatus *status)
+{
+	if ((status)->host_ip)
+		free((status)->host_ip);
+	if ((status)->id)
+		free((status)->id);;
+	if ((status)->value)
+		free((status)->value);
+}
+
+void eulabeia_host_status_destroy(struct EulabeiaHostStatus **status)
+{
+	if (status == NULL || *status == NULL)
+		return;
+
+	free_host_status_data(*status);
+
+	free(*status);
+	*status = NULL;
+}
+
 void eulabeia_scan_progress_destroy(struct EulabeiaScanProgress **scan_progress)
 {
 	unsigned int i;
@@ -321,4 +355,14 @@ enum eulabeia_result_type eulabeia_result_type_from_str(char *rt)
 	EULABEIA_RESULT_TYPES
 #undef X
 	return EULABEIA_RESULT_TYPE_UNKNOWN;
+}
+
+enum eulabeia_host_status_type eulabeia_host_status_type_from_str(char *rt)
+{
+	if (rt == NULL)
+		return EULABEIA_HOST_STATUS_TYPE_UNKNOWN;
+#define X(a, b) else if (strncmp(rt, b, strlen(b)) == 0) return (a);
+	EULABEIA_HOST_STATUS_TYPES
+#undef X
+	return EULABEIA_HOST_STATUS_TYPE_UNKNOWN;
 }


### PR DESCRIPTION
**What**:
Add new Host Status type and function for handling for handling the of messages, to the C library libeulabeia

This type of messages are sent from a scanner to inform the sensor/director about
the host status  host: DEADHOST, HOST_COUNT, HOST_ERRMSG and HOST_PROGRESS.

These messages never end on the client and the are usefull for scan progress calculation.

Related to
Jira: SC-343
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)