### PR TITLE
create storage dir if it doesn't exist

### DIFF
--- a/cmd/eulabeia-director/main.go
+++ b/cmd/eulabeia-director/main.go
@@ -61,14 +61,17 @@ func main() {
 	if err != nil {
 		log.Panicf("Failed create RSA: %s", err)
 	}
-	device := storage.File{Crypt: crypt, Dir: configuration.Director.StoragePath}
+	device, err := storage.New(configuration.Director.StoragePath, crypt)
+	if err != nil {
+		log.Panicf("Failed to create storage: %s", err)
+	}
 	err = client.Subscribe(map[string]connection.OnMessage{
 		prepare_topic("sensor"): handler.New(configuration.Context, sensor.New(device)),
 		prepare_topic("target"): handler.New(configuration.Context, target.New(device)),
 		prepare_topic("scan"):   handler.New(configuration.Context, scan.New(device)),
 	})
 	if err != nil {
-		panic(err)
+		log.Panicf("Subscribing failed: %s", err)
 	}
 
 	process.Block(client)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -134,3 +134,20 @@ func (fs File) Get(id string, v interface{}) error {
 		return err
 	}
 }
+
+// Returns new file system based JSON implementation. The dir is created if it
+// does not exist.
+func New(dir string, crypt Crypt) (*File, error) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err := os.MkdirAll(dir, 0700)
+		if err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	return &File{
+		Dir:   dir,
+		Crypt: crypt,
+	}, nil
+}


### PR DESCRIPTION
**What**:
When the storage directory does not exist it will get created.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The director exited with a panic if the storage directory specified in the config did not exit.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)