### PR TITLE
Make redis socket path configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handling interrupted scans [39](https://github.com/greenbone/eulabeia/pull/39)
 - Possibility to set VT preferences and select VT Groups [43](https://github.com/greenbone/eulabeia/pull/43)
 - Feedservice to handle Get VT [54](https://github.com/greenbone/eulabeia/pull/54)
-- Reolving VT Groups into OIDs [59](https://github.com/greenbone/eulabeia/pull/59)
+- Resolving VT Groups into OIDs [59](https://github.com/greenbone/eulabeia/pull/59)
 
 ### Changed
 - Split cmds and info messages into own module [8](https://github.com/greenbone/eulabeia/pull/8)
 - Normalized topic structure to `group/aggregate/event/destination`; setting topic based on return message rather than configuration [8](https://github.com/greenbone/eulabeia/pull/8)
 - Simplified block until sigterm handling [11](https://github.com/greenbone/eulabeia/pull/11)
 - When sensor is closing stop all scans simultaniously [52](https://github.com/greenbone/eulabeia/pull/52)
+- Make redis socket path configurable [69](https://github.com/greenbone/eulabeia/pull/69)
+
 ### Fixed
 - Fix handling for finished scans [46](https://github.com/greenbone/eulabeia/pull/46)
 ### Removed

--- a/cmd/eulabeia-sensor/main.go
+++ b/cmd/eulabeia-sensor/main.go
@@ -67,7 +67,7 @@ func main() {
 	if err != nil {
 		log.Panicf("Failed to connect: %s", err)
 	}
-	feed := feedservice.NewFeed(client, configuration.Context, configuration.Sensor.Id)
+	feed := feedservice.NewFeed(client, configuration.Context, configuration.Sensor.Id, configuration.RedisDbAddress)
 	log.Printf("Starting Feed Service\n")
 	feed.Start()
 	sens := sensor.NewScheduler(client, configuration.Sensor.Id, configuration.ScannerPreferences, configuration.Context)

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 Context = "scanner"
 title = "eulabeia config"
+RedisDbAddress = "/run/redis-openvas/redis.sock"
 
 [Cert]
 defaultKeyFile = "/usr/var/lib/gvm/private/CA/serverkey.pem"

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type ScannerPreferences struct {
 	MaxQueuedScans      int64  // Maxi number of scans that can be queued
 	Niceness            int64  // Niceness of the openvas Process
 	MinFreeMemScanQueue uint64 // Min Memory necessary for a Scan to start
+
 }
 
 type Preferences struct {
@@ -53,6 +54,7 @@ type Director struct {
 type Configuration struct {
 	Context            string
 	Certificate        Certificate
+	RedisDbAddress     string
 	Connection         Connection
 	ScannerPreferences ScannerPreferences
 	Preferences        Preferences

--- a/feedservice/feedservice.go
+++ b/feedservice/feedservice.go
@@ -261,11 +261,11 @@ func (f *feed) Close() error {
 }
 
 // NewScheduler creates a new scheduler
-func NewFeed(mqtt connection.PubSub, context string, id string) *feed {
+func NewFeed(mqtt connection.PubSub, context string, id string, redisDbAddress string) *feed {
 	return &feed{
 		mqtt:    mqtt,
 		context: context,
-		rc:      redis.NewRedisConnection("unix", "/run/redis-openvas/redis.sock"),
+		rc:      redis.NewRedisConnection("unix", redisDbAddress),
 		id:      id,
 	}
 }


### PR DESCRIPTION
**What**:
Make redis socket path configurable
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Because the path to the redis socket was hardcoded.
<!-- Why are these changes necessary? -->

**How**:
Set the redis path in the config.toml file in the general configuration 
```
dbAddress = "/tmp/redis-openvas.sock"
```
and call some cmd involving the feedservice. See PR #59 for an example

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)