### PR TITLE
Fix: disable test when building openvas

### DIFF
--- a/.docker/descriptions/openvas/debian/patches/dont-test
+++ b/.docker/descriptions/openvas/debian/patches/dont-test
@@ -1,19 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 589c1dd1..c049b6a6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -202,7 +202,7 @@ configure_file (src/openvas_log_conf.cma
+@@ -228,7 +228,7 @@ add_subdirectory (doc)
  
  ## Testing
  
 -enable_testing ()
-+#enable_testing ()
++# enable_testing ()
  
  add_custom_target (tests
-                    DEPENDS attack-test pcap-test)
-@@ -235,6 +235,6 @@ add_subdirectory (doc)
- 
- ## Tests
- 
--enable_testing ()
-+#enable_testing ()
- 
- ## End
+                    DEPENDS pcap-test)

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,6 @@ start-sensor:
 	docker volume create eulabeia_feed
 	docker run -d --rm -v eulabeia_redis_socket:/run/redis --name eulabeia_redis $(REPOSITORY)/eulabeia-redis
 	$(MQTT_CONTAINER) -d -v eulabeia_feed:/var/lib/openvas/feed/plugins -v eulabeia_redis_socket:/run/redis --name eulabeia_sensor $(REPOSITORY)/eulabeia-sensor
-	docker cp test.nasl eulabeia_sensor:/var/lib/openvas/feed/plugins/test.nasl
-	docker cp plugin_feed_info.inc eulabeia_sensor:/var/lib/openvas/feed/plugins/plugin_feed_info.inc
 	docker exec eulabeia_sensor chmod 777 /var/lib/openvas/feed/plugins/plugin_feed_info.inc
 	docker exec eulabeia_sensor mkdir -p /etc/openvas
 	docker exec eulabeia_sensor bash -c 'echo "mqtt_server_uri = $(BROKER_IP):9138" >> /etc/openvas/openvas.conf'

--- a/sensor.Dockerfile
+++ b/sensor.Dockerfile
@@ -22,5 +22,7 @@ RUN rm /etc/apt/sources.list.d/docker.list
 COPY openvas_log.conf /etc/openvas/openvas_log.conf
 COPY config.toml /usr/etc/eulabeia/config.toml
 COPY bin/eulabeia-sensor /usr/bin/eulabeia-sensor
+COPY *.nasl /var/lib/openvas/feed/plugins/
+COPY plugin_feed_info.inc /var/lib/openvas/feed/plugins/
 RUN echo "mqtt_context = scanner" >> /etc/openvas/openvas.conf
 CMD [ "/usr/bin/eulabeia-sensor" ]


### PR DESCRIPTION
When building openvas via the current debian packaging pcap-test will be
missing and therefore the tests will cannot be executed and fail.

This commit fixes the line of disabling the tests via patch.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)