### PR TITLE
Add: get all vts when id is missing in get vt message

### DIFF
--- a/client/init.go
+++ b/client/init.go
@@ -384,6 +384,13 @@ func GotVTParser(b []byte) (string, messages.Event, error) {
 	}
 	return "got", c, nil
 }
+func GotAllVTsParser(b []byte) (string, messages.Event, error) {
+	var c models.GotVTs
+	if err := json.Unmarshal(b, &c); err != nil {
+		return "", nil, err
+	}
+	return "gotall", c, nil
+}
 func GotSensorParser(b []byte) (string, messages.Event, error) {
 	var c models.GotSensor
 	if err := json.Unmarshal(b, &c); err != nil {
@@ -456,7 +463,11 @@ func From(
 		case "result":
 			parser = GotResultParser
 		case "vt":
-			parser = GotVTParser
+			if v.GetID() != "" {
+				parser = GotVTParser
+			} else {
+				parser = GotAllVTsParser
+			}
 		default:
 			return nil, fmt.Errorf("no known parser for %s", v.MessageType().Aggregate)
 		}

--- a/cmd/example-client/main.go
+++ b/cmd/example-client/main.go
@@ -76,8 +76,8 @@ var target = models.Target{
 	},
 }
 
-func verifyGetVT(cc client.Configuration) {
-	p, err := client.From(cc, cmds.NewGet("vt", "0.0.0.0.0.0.0.0.0.1", "director", "getvts"))
+func verifyGetVT(cc client.Configuration, oid string) {
+	p, err := client.From(cc, cmds.NewGet("vt", oid, "director", "getvts"))
 	if err != nil {
 		log.Panic().Err(err).Msg("Unable to create program for get.vts")
 	}
@@ -186,5 +186,6 @@ func main() {
 	}(received)
 	cc.DownStream = received
 	_ = verifyStartScan(cc)
-	verifyGetVT(cc)
+	verifyGetVT(cc, "0.0.0.0.0.0.0.0.0.1")
+	verifyGetVT(cc, "")
 }

--- a/feedservice/feedservice_test.go
+++ b/feedservice/feedservice_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/greenbone/eulabeia/messages/cmds"
 	"github.com/greenbone/eulabeia/models"
 )
 
@@ -199,8 +198,8 @@ func TestGetVT(t *testing.T) {
 		rc:      &RedisMock{},
 	}
 
-	vtTest, f, err := fs.GetVT(cmds.NewGet("vt", "test", "", ""))
-	if err != nil || f != nil {
+	vtTest, err := fs.GetVT("test")
+	if err != nil {
 		t.Fatalf("Unable to get VT: %s\n", err)
 	}
 
@@ -221,6 +220,37 @@ func TestGetVT(t *testing.T) {
 			vtJSON,
 		)
 	}
+}
+
+func TestGetAllVTs(t *testing.T) {
+	fs := feed{
+		context: "",
+		rc:      &RedisMock{},
+	}
+
+	vtsTest, err := fs.GetAllVTs()
+	if err != nil {
+		t.Fatalf("Unable to get all VTs: %s\n", err)
+	}
+
+	if len(vtsTest) != 2 {
+		t.Fatalf("Wrong number of VTs, expected %d got %d", 2, len(vtsTest))
+	}
+
+	vtTestJSON, err := json.Marshal(vtsTest[0])
+	if err != nil {
+		t.Fatalf("Unable to get JSON of TestVT: %s\n", err)
+	}
+
+	vtJSON, err := json.Marshal(vt)
+	if err != nil {
+		t.Fatalf("Unable to get JSON of VT: %s\n", err)
+	}
+
+	if string(vtTestJSON) != string(vtJSON) {
+		t.Fatalf("vtTestJSON != vtJSON\n\nvtTestJSON:\n %s\n\n vtJSON:\n%s\n", vtTestJSON, vtJSON)
+	}
+
 }
 
 func TestResolveFilter(t *testing.T) {

--- a/models/target.go
+++ b/models/target.go
@@ -91,6 +91,12 @@ type GotVT struct {
 	VT
 }
 
+type GotVTs struct {
+	messages.Message
+	info.EventType
+	VTs []VT `json:"vts"`
+}
+
 // ResolveFilter is a request to get all OIDs matching the given Filter
 type ResolveFilter struct {
 	cmds.EventType


### PR DESCRIPTION
**What**:
Add the functionality to get information about all VTs at once when leaving the id field empty.
SC-392

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
For some clients it is necessary to get information about all VTs before getting a corresponding result.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/eulabeia/blob/master/CHANGELOG.md) Entry
- [ ] [DOCUMENTATION](https://github.com/greenbone/eulabeia/tree/main/docs)